### PR TITLE
changing all default import/export to named import/export

### DIFF
--- a/src/components/EditButton.jsx
+++ b/src/components/EditButton.jsx
@@ -11,7 +11,7 @@ const DoneIcon = () => (
   </svg>
 );
 
-export default function EditButton({ handleClick, isEditing }) {
+export function EditButton({ handleClick, isEditing }) {
   const text = isEditing ? "Done" : "Edit";
   const IconComponent = isEditing ? DoneIcon : EditIcon;
 

--- a/src/components/WhiteboardWrapper.jsx
+++ b/src/components/WhiteboardWrapper.jsx
@@ -1,8 +1,8 @@
 import { useState, useEffect } from "react";
-import EditButton from "./EditButton";
-import Whiteboard from "./whiteboard";
+import { EditButton } from "./EditButton";
+import { Whiteboard } from "./whiteboard";
 
-export default function WhiteboardWrapper() {
+export function WhiteboardWrapper() {
   const [isEditing, setIsEditing] = useState(false);
 
   const toggleEditing = () => {

--- a/src/components/whiteboard/index.tsx
+++ b/src/components/whiteboard/index.tsx
@@ -4,7 +4,7 @@ import { Controls } from './components/controls'
 import { useKeyboardShortcuts, useRecenterContentOnWindowResize } from './hooks'
 import styles from './whiteboard.module.css';
 
-function Whiteboard({ isEditing }): JSX.Element {
+export function Whiteboard({ isEditing }): JSX.Element {
   useKeyboardShortcuts()
   useRecenterContentOnWindowResize()
 
@@ -16,5 +16,3 @@ function Whiteboard({ isEditing }): JSX.Element {
     </div>
   )
 }
-
-export default Whiteboard

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from "../layouts/Layout.astro";
-import WhiteboardWrapper from "../components/WhiteboardWrapper.jsx";
+import { WhiteboardWrapper } from "../components/WhiteboardWrapper.jsx";
 import PageTitle from "../components/PageTitle.astro";
 import creativityTools from "../../public/creativity-tools/data.json";
 import metadata from "../site-metadata.json";


### PR DESCRIPTION
Issue #6 - Prefer named import/export of components
Dear Team,
I have changed all the default export/import in react components to named import/exports. 

If, by any chance, I have missed any instances, please do not hesitate to inform me, and I will promptly rectify the oversight.

I appreciate the opportunity to contribute to your project during Hacktoberfest and look forward to any further feedback or tasks.

Sincerely,
Kunal
