### PR TITLE
Removed unused instances of `import * as React from 'react'` from the codebase. 

### DIFF
--- a/src/components/Whiteboard/components/Controls/ColorBar.tsx
+++ b/src/components/Whiteboard/components/Controls/ColorBar.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import styles from './ColorBar.module.css'
 import COLORS from '../../colors.json'
 

--- a/src/components/Whiteboard/components/Controls/MenuBar.tsx
+++ b/src/components/Whiteboard/components/Controls/MenuBar.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import styles from './MenuBar.module.css'
 import { app } from '../../state'
 

--- a/src/components/Whiteboard/components/DevPanel/Checkbox.tsx
+++ b/src/components/Whiteboard/components/DevPanel/Checkbox.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import * as Label from '@radix-ui/react-label'
 import {
   Root,

--- a/src/components/Whiteboard/components/Editor/Editor.tsx
+++ b/src/components/Whiteboard/components/Editor/Editor.tsx
@@ -1,4 +1,3 @@
-import * as React from 'react'
 import { Renderer } from '@tldraw/core'
 import { app, useAppState } from '../../state'
 import styles from './Editor.module.css'


### PR DESCRIPTION
Issue https://github.com/bryanbraun/lets-get-creative/issues/4 - Update on Delete unused imports https://github.com/bryanbraun/lets-get-creative/issues/4

Hi Team,

I wanted to provide an update regarding Issue - Delete unused imports https://github.com/bryanbraun/lets-get-creative/issues/4  where I have made sure that unused imports have been removed from codebase and neccesary imports kept as it is.
Tested the application to ensure there are no adverse effects after removing import statment
Verified that the components still function as expected after the import changes.
Reviewed the affected files to confirm that only unnecessary import * as React from 'react' statements were removed.

If, by any chance, I have missed any instances, please do not hesitate to inform me, and I will promptly rectify the oversight.

I appreciate the opportunity to contribute to your project during Hacktoberfest and look forward to any further feedback or tasks.

Sincerely,
Shrinivas Kulkarni